### PR TITLE
feat: Migrate to GitHub CI and cleanup

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,7 +42,8 @@ jobs:
         oci: true
         arch: ${{ matrix.arch }}
         context: images/shim
-        dockerfiles: ./images/shim/Containerfile
+        build-args: VERSION=${{ env.TAG }}
+        containerfiles: ./images/shim/Containerfile
     
     - name: push to ghcr
       id: push-to-ghcr

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -27,8 +27,8 @@ jobs:
        mkdir -vp ~/.config/containers
        printf "[storage.options]\nmount_program=\"/usr/bin/fuse-overlayfs\"" > ~/.config/containers/storage.conf
 
-    - name: get git short hash
-      run: echo "SHORT_SHA=${GITHUB_SHA::8}" >> $GITHUB_ENV
+    - name: get git tag
+      run: echo "TAG=${GITHUB_REF##*/}" >> $GITHUB_ENV
     
     - name: setup multi-arch builds
       run: sudo podman run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -38,7 +38,7 @@ jobs:
       uses: redhat-actions/buildah-build@v2.7
       with:
         image: tooling
-        tags: ${{ env.GITHUB_REF }} latest
+        tags: ${{ env.TAG }} latest
         oci: true
         arch: ${{ matrix.arch }}
         context: images/shim

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
     tags-ignore:
       - '**'
     branches:
-      - main
+      - '**'
   pull_request:
     branches:
       - main

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,5 +47,6 @@ jobs:
         oci: true
         arch: ${{ matrix.arch }}
         context: images/shim
-        dockerfiles: ./images/shim/Containerfile
+        build-args: VERSION=${{ env.TAG }}
+        containerfiles: ./images/shim/Containerfile
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,6 @@ jobs:
         oci: true
         arch: ${{ matrix.arch }}
         context: images/shim
-        build-args: VERSION=${{ env.TAG }}
+        build-args: VERSION=${{ env.SHORT_SHA }}
         containerfiles: ./images/shim/Containerfile
 

--- a/images/shim/Containerfile
+++ b/images/shim/Containerfile
@@ -1,6 +1,5 @@
 FROM docker.io/library/archlinux@sha256:5731615d9dd521f86bf75c0f092ea322e58e793e95541c7b7d5a9c43fd9c21f0
 
-ENV NAME=archlinux-toolbox
 LABEL com.github.containers.toolbox="true" \
       com.github.debarshiray.toolbox="true" \
       name="archlinux-toolbox" \
@@ -61,4 +60,4 @@ COPY mirrorupgrade.hook /etc/pacman.d/hooks/mirrorupgrade.hook
 
 CMD ["/bin/sh"]
 
-LABEL org.opencontainers.image.source = &quot;https://github.com/anthr76/tooling
+LABEL org.opencontainers.image.source = https://github.com/anthr76/tooling

--- a/images/shim/Containerfile
+++ b/images/shim/Containerfile
@@ -1,9 +1,9 @@
 FROM docker.io/library/archlinux@sha256:5731615d9dd521f86bf75c0f092ea322e58e793e95541c7b7d5a9c43fd9c21f0
 
-ENV NAME=archlinux-toolbox VERSION=base
+ENV NAME=archlinux-toolbox
 LABEL com.github.containers.toolbox="true" \
       com.github.debarshiray.toolbox="true" \
-      name="$NAME" \
+      name="archlinux-toolbox" \
       version="$VERSION" \
       usage="This image is meant to be used with the toolbox command" \
       summary="You should not use this container and instead use your own customizations on a fork" \

--- a/images/shim/Containerfile
+++ b/images/shim/Containerfile
@@ -1,5 +1,7 @@
 FROM docker.io/library/archlinux@sha256:5731615d9dd521f86bf75c0f092ea322e58e793e95541c7b7d5a9c43fd9c21f0
 
+ARG VERSION
+
 LABEL com.github.containers.toolbox="true" \
       com.github.debarshiray.toolbox="true" \
       name="archlinux-toolbox" \

--- a/images/shim/Containerfile
+++ b/images/shim/Containerfile
@@ -61,4 +61,4 @@ COPY mirrorupgrade.hook /etc/pacman.d/hooks/mirrorupgrade.hook
 
 CMD ["/bin/sh"]
 
-LABEL org.opencontainers.image.source https://gitlab.com/kutara/tooling
+LABEL org.opencontainers.image.source = &quot;https://github.com/anthr76/tooling


### PR DESCRIPTION
General CI tweaks and QoL..

This image will likely be pushed to quay again as `quay.io/kutara/tooling` for the time being only on GHCR. Also caching and temporary layers at another time.

Closes: https://github.com/anthr76/tooling/pull/5